### PR TITLE
Refactor FileSystem.CheckReferrer

### DIFF
--- a/pkg/filesystem/config.go
+++ b/pkg/filesystem/config.go
@@ -10,7 +10,6 @@ package filesystem
 import (
 	"github.com/containerd/nydus-snapshotter/pkg/cache"
 	"github.com/containerd/nydus-snapshotter/pkg/manager"
-	"github.com/containerd/nydus-snapshotter/pkg/referrer"
 	"github.com/containerd/nydus-snapshotter/pkg/signature"
 	"github.com/containerd/nydus-snapshotter/pkg/stargz"
 	"github.com/containerd/nydus-snapshotter/pkg/tarfs"
@@ -45,17 +44,6 @@ func WithCacheManager(cm *cache.Manager) NewFSOpt {
 		}
 
 		fs.cacheMgr = cm
-		return nil
-	}
-}
-
-func WithReferrerManager(rm *referrer.Manager) NewFSOpt {
-	return func(fs *Filesystem) error {
-		if rm == nil {
-			return errors.New("referrer manager cannot be nil")
-		}
-
-		fs.referrerMgr = rm
 		return nil
 	}
 }

--- a/pkg/filesystem/fs.go
+++ b/pkg/filesystem/fs.go
@@ -37,7 +37,6 @@ import (
 	"github.com/containerd/nydus-snapshotter/pkg/label"
 	"github.com/containerd/nydus-snapshotter/pkg/manager"
 	racache "github.com/containerd/nydus-snapshotter/pkg/rafs"
-	"github.com/containerd/nydus-snapshotter/pkg/referrer"
 	"github.com/containerd/nydus-snapshotter/pkg/signature"
 	"github.com/containerd/nydus-snapshotter/pkg/stargz"
 	"github.com/containerd/nydus-snapshotter/pkg/tarfs"
@@ -48,7 +47,6 @@ type Filesystem struct {
 	fscacheSharedDaemon *daemon.Daemon
 	enabledManagers     map[string]*manager.Manager
 	cacheMgr            *cache.Manager
-	referrerMgr         *referrer.Manager
 	stargzResolver      *stargz.Resolver
 	tarfsMgr            *tarfs.Manager
 	verifier            *signature.Verifier

--- a/pkg/filesystem/referer_adaptor.go
+++ b/pkg/filesystem/referer_adaptor.go
@@ -6,55 +6,7 @@
 
 package filesystem
 
-import (
-	"context"
-	"fmt"
-	"os"
-
-	"github.com/containerd/log"
-
-	snpkg "github.com/containerd/containerd/v2/pkg/snapshotters"
-	"github.com/opencontainers/go-digest"
-	"github.com/pkg/errors"
-)
-
-func (fs *Filesystem) ReferrerDetectEnabled() bool {
-	return fs.referrerMgr != nil
-}
-
-func (fs *Filesystem) CheckReferrer(ctx context.Context, labels map[string]string) bool {
-	if !fs.ReferrerDetectEnabled() {
-		return false
-	}
-
-	ref, ok := labels[snpkg.TargetRefLabel]
-	if !ok {
-		return false
-	}
-
-	manifestDigest := digest.Digest(labels[snpkg.TargetManifestDigestLabel])
-	if manifestDigest.Validate() != nil {
-		return false
-	}
-
-	if _, err := fs.referrerMgr.CheckReferrer(ctx, ref, manifestDigest); err != nil {
-		return false
-	}
-
-	return true
-}
-
-func (fs *Filesystem) TryFetchMetadata(ctx context.Context, labels map[string]string, metadataPath string) error {
-	ref, ok := labels[snpkg.TargetRefLabel]
-	if !ok {
-		return fmt.Errorf("empty label %s", snpkg.TargetRefLabel)
-	}
-
-	manifestDigest := digest.Digest(labels[snpkg.TargetManifestDigestLabel])
-	if err := manifestDigest.Validate(); err != nil {
-		return fmt.Errorf("invalid label %s=%s", snpkg.TargetManifestDigestLabel, manifestDigest)
-	}
-
+func (fs *Filesystem) WithMetadataPathLock(metadataPath string, f func() error) error {
 	// Acquire a per-path mutex to serialize concurrent fetches to the same metadata file.
 	// This prevents race conditions when multiple containers start simultaneously on the
 	// same image with referrer detection enabled - they all find the same parent snapshot
@@ -63,16 +15,5 @@ func (fs *Filesystem) TryFetchMetadata(ctx context.Context, labels map[string]st
 	mu.Lock()
 	defer mu.Unlock()
 
-	// Check if metadata file already exists to avoid redundant fetches.
-	// This is safe now because we hold the mutex.
-	if _, err := os.Stat(metadataPath); err == nil {
-		log.L.Debugf("Metadata file %s already exists, skipping fetch", metadataPath)
-		return nil
-	}
-
-	if err := fs.referrerMgr.TryFetchMetadata(ctx, ref, manifestDigest, metadataPath); err != nil {
-		return errors.Wrap(err, "try fetch metadata")
-	}
-
-	return nil
+	return f()
 }

--- a/snapshot/process.go
+++ b/snapshot/process.go
@@ -82,7 +82,7 @@ func chooseProcessor(ctx context.Context, logger *logrus.Entry,
 		case label.IsNydusDataLayer(labels):
 			logger.Debugf("found nydus data layer")
 			handler = skipHandler
-		case sn.fs.CheckReferrer(ctx, labels):
+		case sn.checkReferrer(ctx, labels):
 			logger.Debugf("found referenced nydus manifest")
 			handler = skipHandler
 		default:
@@ -141,11 +141,11 @@ func chooseProcessor(ctx context.Context, logger *logrus.Entry,
 			}
 		}
 
-		if handler == nil && sn.fs.ReferrerDetectEnabled() {
+		if handler == nil && sn.referrerDetectEnabled() {
 			if id, info, err := sn.findReferrerLayer(ctx, key); err == nil {
 				logger.Infof("Found referenced nydus manifest for image: %s", info.Labels[snpkg.TargetRefLabel])
 				metaPath := path.Join(sn.snapshotDir(id), "fs", "image.boot")
-				if err := sn.fs.TryFetchMetadata(ctx, info.Labels, metaPath); err != nil {
+				if err := sn.tryFetchMetadata(ctx, info.Labels, metaPath); err != nil {
 					return nil, "", errors.Wrap(err, "try fetch metadata")
 				}
 				handler = remoteHandler(id, info.Labels)

--- a/snapshot/snapshot.go
+++ b/snapshot/snapshot.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
 
 	"github.com/containerd/containerd/v2/core/mount"
@@ -55,6 +56,7 @@ type snapshotter struct {
 	ms                   *storage.MetaStore // Storing snapshots' state, parentage and other metadata
 	fs                   *filesystem.Filesystem
 	cgroupManager        *cgroup.Manager
+	referrerMgr          *referrer.Manager
 	enableNydusOverlayFS bool
 	nydusOverlayFSPath   string
 	enableKataVolume     bool
@@ -223,9 +225,9 @@ func NewSnapshotter(ctx context.Context, cfg *config.SnapshotterConfig) (snapsho
 	}
 	opts = append(opts, filesystem.WithCacheManager(cacheMgr))
 
+	var referrerMgr *referrer.Manager
 	if cfg.Experimental.EnableReferrerDetect {
-		referrerMgr := referrer.NewManager(skipSSLVerify)
-		opts = append(opts, filesystem.WithReferrerManager(referrerMgr))
+		referrerMgr = referrer.NewManager(skipSSLVerify)
 	}
 
 	if cfg.Experimental.TarfsConfig.EnableTarfs {
@@ -294,6 +296,7 @@ func NewSnapshotter(ctx context.Context, cfg *config.SnapshotterConfig) (snapsho
 		syncRemove:           syncRemove,
 		fs:                   nydusFs,
 		cgroupManager:        cgroupMgr,
+		referrerMgr:          referrerMgr,
 		enableNydusOverlayFS: cfg.SnapshotsConfig.EnableNydusOverlayFS,
 		nydusOverlayFSPath:   cfg.SnapshotsConfig.NydusOverlayFSPath,
 		enableKataVolume:     cfg.SnapshotsConfig.EnableKataVolume,
@@ -425,7 +428,7 @@ func (o *snapshotter) Mounts(ctx context.Context, key string) ([]mount.Mount, er
 	case snapshots.KindUnknown:
 	}
 
-	if o.fs.ReferrerDetectEnabled() && !needRemoteMounts {
+	if o.referrerDetectEnabled() && !needRemoteMounts {
 		if id, _, err := o.findReferrerLayer(ctx, key); err == nil {
 			needRemoteMounts = true
 			metaSnapshotID = id
@@ -719,7 +722,7 @@ func (o *snapshotter) workPath(id string) string {
 
 func (o *snapshotter) findReferrerLayer(ctx context.Context, key string) (string, snapshots.Info, error) {
 	return snapshot.IterateParentSnapshots(ctx, o.ms, key, func(_ string, info snapshots.Info) bool {
-		return o.fs.CheckReferrer(ctx, info.Labels)
+		return o.checkReferrer(ctx, info.Labels)
 	})
 }
 
@@ -982,6 +985,59 @@ func (o *snapshotter) mergeTarfs(ctx context.Context, s storage.Snapshot, pID st
 	return nil
 }
 
+func (o *snapshotter) referrerDetectEnabled() bool {
+	return o.referrerMgr != nil
+}
+
+func (o *snapshotter) checkReferrer(ctx context.Context, labels map[string]string) bool {
+	if !o.referrerDetectEnabled() {
+		return false
+	}
+
+	ref, ok := labels[snpkg.TargetRefLabel]
+	if !ok {
+		return false
+	}
+
+	manifestDigest := digest.Digest(labels[snpkg.TargetManifestDigestLabel])
+	if manifestDigest.Validate() != nil {
+		return false
+	}
+
+	if _, err := o.referrerMgr.CheckReferrer(ctx, ref, manifestDigest); err != nil {
+		return false
+	}
+
+	return true
+}
+
+func (o *snapshotter) tryFetchMetadata(ctx context.Context, labels map[string]string, metadataPath string) error {
+	ref, ok := labels[snpkg.TargetRefLabel]
+	if !ok {
+		return fmt.Errorf("empty label %s", snpkg.TargetRefLabel)
+	}
+
+	manifestDigest := digest.Digest(labels[snpkg.TargetManifestDigestLabel])
+	if err := manifestDigest.Validate(); err != nil {
+		return fmt.Errorf("invalid label %s=%s", snpkg.TargetManifestDigestLabel, manifestDigest)
+	}
+
+	return o.fs.WithMetadataPathLock(metadataPath, func() error {
+		// Check if metadata file already exists to avoid redundant fetches.
+		// This is safe now because we hold the mutex.
+		if _, err := os.Stat(metadataPath); err == nil {
+			log.L.Debugf("Metadata file %s already exists, skipping fetch", metadataPath)
+			return nil
+		}
+
+		if err := o.referrerMgr.TryFetchMetadata(ctx, ref, manifestDigest, metadataPath); err != nil {
+			return errors.Wrap(err, "try fetch metadata")
+		}
+
+		return nil
+	})
+}
+
 func bindMount(source, roFlag string) []mount.Mount {
 	return []mount.Mount{
 		{
@@ -1065,7 +1121,7 @@ func (o *snapshotter) mountRemote(ctx context.Context, labels map[string]string,
 	}
 
 	lowerPaths := make([]string, 0, 8)
-	if o.fs.ReferrerDetectEnabled() {
+	if o.referrerDetectEnabled() {
 		// From the parent list, we want to add all the layers
 		// between the upmost snapshot and the nydus meta snapshot.
 		// On the other hand, we consider that all the layers below


### PR DESCRIPTION
The Filesystem type deals with files and daemons. It's not its responsibility to communicate with the registry.

The CheckReferrer and related functionality better belongs in the snapshotter.