### PR TITLE
Cache negative referrer hits

### DIFF
--- a/pkg/referrer/manager.go
+++ b/pkg/referrer/manager.go
@@ -11,12 +11,15 @@ import (
 
 	"github.com/containerd/log"
 	"github.com/containerd/nydus-snapshotter/pkg/auth"
+	"github.com/containerd/nydus-snapshotter/pkg/errdefs"
 	"github.com/golang/groupcache/lru"
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 	"golang.org/x/sync/singleflight"
 )
+
+type noReferrers struct{}
 
 type Manager struct {
 	insecure bool
@@ -39,9 +42,12 @@ func NewManager(insecure bool) *Manager {
 func (manager *Manager) CheckReferrer(ctx context.Context, ref string, manifestDigest digest.Digest) (*ocispec.Descriptor, error) {
 	metaLayer, err, _ := manager.sg.Do(manifestDigest.String(), func() (interface{}, error) {
 		// Try to get nydus metadata layer descriptor from LRU cache.
-		if metaLayer, ok := manager.cache.Get(manifestDigest); ok {
-			desc := metaLayer.(ocispec.Descriptor)
-			return &desc, nil
+		if hit, ok := manager.cache.Get(manifestDigest); ok {
+			if desc, ok := hit.(ocispec.Descriptor); ok {
+				return &desc, nil
+			} else if _, ok = hit.(noReferrers); ok {
+				return nil, errdefs.ErrNotFound
+			}
 		}
 
 		keyChain, err := auth.GetKeyChainByRef(ref, nil)
@@ -54,11 +60,12 @@ func (manager *Manager) CheckReferrer(ctx context.Context, ref string, manifestD
 		referrer := newReferrer(keyChain, manager.insecure)
 		metaLayer, err := referrer.checkReferrer(ctx, ref, manifestDigest)
 		if err != nil {
+			manager.cache.Add(manifestDigest, noReferrers{})
 			return nil, errors.Wrap(err, "check referrer")
+		} else {
+			// FIXME: how to invalidate the LRU cache if referrers update?
+			manager.cache.Add(manifestDigest, *metaLayer)
 		}
-
-		// FIXME: how to invalidate the LRU cache if referrers update?
-		manager.cache.Add(manifestDigest, *metaLayer)
 
 		return metaLayer, nil
 	})
@@ -69,6 +76,12 @@ func (manager *Manager) CheckReferrer(ctx context.Context, ref string, manifestD
 	}
 
 	return metaLayer.(*ocispec.Descriptor), nil
+}
+
+func (manager *Manager) RemoveReferrer(ctx context.Context, manifestDigest digest.Digest) error {
+	log.L.WithField("manifestDigest", manifestDigest).Debug("Removing from referrer cache")
+	manager.cache.Remove(manifestDigest)
+	return nil
 }
 
 // TryFetchMetadata try to fetch and unpack nydus metadata file to specified path.

--- a/snapshot/snapshot.go
+++ b/snapshot/snapshot.go
@@ -637,6 +637,10 @@ func (o *snapshotter) Remove(ctx context.Context, key string) error {
 		}()
 	}
 
+	if manifestDigest, ok := info.Labels[snpkg.TargetManifestDigestLabel]; ok {
+		_ = o.referrerMgr.RemoveReferrer(ctx, digest.Digest(manifestDigest))
+	}
+
 	_, _, err = storage.Remove(ctx, key)
 	if err != nil {
 		return errors.Wrapf(err, "failed to remove key %s", key)
@@ -1007,7 +1011,6 @@ func (o *snapshotter) checkReferrer(ctx context.Context, labels map[string]strin
 	if _, err := o.referrerMgr.CheckReferrer(ctx, ref, manifestDigest); err != nil {
 		return false
 	}
-
 	return true
 }
 


### PR DESCRIPTION
If a referrer check fails (presumably b/c there are no referrers), cache the fact to avoid performing numerous checks in a row.

The cache is cleaned up with the snapshot is removed.
